### PR TITLE
Add functionality to set text for input node

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A quick and dirty GUI library for [Defold](https://www.defold.com/).
    * *Text Triggers*: Input: `text`, Action: `text`
    * *Text Triggers*: Input: `marked-text`, Action: `marked_text`
    
-    For more usage examples take a look at [main/examples.gui_script](main/examples.gui_script) and [dirtylarry/dirtylarry.lua](dirtylarry/dirtylarry.lua) for configurational options.
+For more usage examples take a look at [main/examples.gui_script](main/examples.gui_script) and [dirtylarry/dirtylarry.lua](dirtylarry/dirtylarry.lua) for configurational options.
 
 ## Examples
 * Using the built in font:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A quick and dirty GUI library for [Defold](https://www.defold.com/).
 4. Then add the corresponding function inside your `on_input`:
     * `dirtylarry/input.gui`:
     ```Lua
-    print(dirtylarry:input("node_id", action_id, action, gui.KEYBOARD_TYPE_DEFAULT, "Default text"))
+    dirtylarry:input("node_id", action_id, action, gui.KEYBOARD_TYPE_DEFAULT, "Default text")
     ```
     * `dirtylarry/button.gui`:
     ```Lua
@@ -31,6 +31,12 @@ A quick and dirty GUI library for [Defold](https://www.defold.com/).
     self.radio_value = dirtylarry:radio("node_b_id", action_id, action, "b", self.radio_value)
     ```
 
+5. In the `input/game.input_binding`, add the following triggers:
+   * *Key Triggers*: Input: `key-backspace`, Action: `backspace`
+   * *Mouse Triggers*: Input: `mouse-button-1`, Action: `touch`
+   * *Text Triggers*: Input: `text`, Action: `text`
+   * *Text Triggers*: Input: `marked-text`, Action: `marked_text`
+   
     For more usage examples take a look at [main/examples.gui_script](main/examples.gui_script) and [dirtylarry/dirtylarry.lua](dirtylarry/dirtylarry.lua) for configurational options.
 
 ## Examples

--- a/dirtylarry/dirtylarry.lua
+++ b/dirtylarry/dirtylarry.lua
@@ -109,7 +109,7 @@ function dirtylarry.radio(self, node, action_id, action, id, value)
     return value
 end
 
-function dirtylarry.input(self, node, action_id, action, type, empty_text)
+function dirtylarry.input(self, node, action_id, action, type, empty_text, set_text)
 
     local node_bg = gui.get_node(node .. "/bg")
     local node_inner = gui.get_node(node .. "/inner")
@@ -126,6 +126,12 @@ function dirtylarry.input(self, node, action_id, action, type, empty_text)
     end
 
     local input_node = dirtylarry.input_nodes[key]
+    
+    if set_text ~= nil then
+    	input_node.data = set_text
+    	gui.set_text(node_content,set_text)
+    end
+
     if not dirtylarry.is_enabled(self, node_bg) then
         return input_node.data
     end


### PR DESCRIPTION
Added the **set_text** parameter to dirtylarry:input() method. If this parameter is set (i.e. not nil), then the text on the input field is set to this parameter's value. Passing an empty string will set the input field to empty. Type of value is not checked.