### PR TITLE
Replace string.gfind by string.gmatch (renamed in Lua 5.1)

### DIFF
--- a/dirtylarry/dirtylarry.lua
+++ b/dirtylarry/dirtylarry.lua
@@ -184,7 +184,7 @@ function dirtylarry.input(self, node, action_id, action, type, empty_text)
         -- input deletion
         elseif (action_id == dirtylarry.action_id_backspace and (action.pressed or action.repeated)) then
             local last_s = 0
-            for uchar in string.gfind(dirtylarry.active_node.data, dirtylarry.utf8_gfind) do
+            for uchar in string.gmatch(dirtylarry.active_node.data, dirtylarry.utf8_gfind) do
               last_s = string.len(uchar)
             end
 
@@ -214,7 +214,7 @@ function dirtylarry.input(self, node, action_id, action, type, empty_text)
     -- if input field is a password, mask the text output
     if (type == gui.KEYBOARD_TYPE_PASSWORD) then
         local masked_text = ""
-        for uchar in string.gfind(text_output, dirtylarry.utf8_gfind) do
+        for uchar in string.gmatch(text_output, dirtylarry.utf8_gfind) do
           masked_text = masked_text .. "*"
         end
         text_output = masked_text


### PR DESCRIPTION
Hi,

`string.gfind` was deprecated and has been renamed to `string.gmatch` in Lua 5.1:
[https://www.lua.org/manual/5.1/manual.html](https://www.lua.org/manual/5.1/manual.html)

It looks like Defold recently updated its version of Lua as DirtyLarry is not working anymore with the old function name.